### PR TITLE
Updated the image to reference the values imageHub value

### DIFF
--- a/chart/templates/operator.yml
+++ b/chart/templates/operator.yml
@@ -115,7 +115,7 @@ spec:
             - start
             - --max-concurrent-reconciles
             - "3"
-          image: "docker.io/cnvrg/cnvrg-operator:{{ .Chart.Version }}"
+          image: "{{ .Values.imageHub }}/cnvrg-operator:{{ .Chart.Version }}"
           imagePullPolicy: Always
           name: cnvrg-operator
           resources:


### PR DESCRIPTION
When doing airgap installs we need to be able to update the image path for the operator. This change points the operator image to the registry value defined in the key "imageHub". 