### PR TITLE
DEV-15948-pre-post-job-image-update

### DIFF
--- a/chart/templates/hooks.yml
+++ b/chart/templates/hooks.yml
@@ -68,7 +68,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
         - name: cnvrgapp
-          image: docker.io/cnvrg/cnvrg-tools:v0.3
+          image: "{{ .Values.imageHub }}/cnvrg-tools:v0.3"
           args:
             - /bin/bash
             - -c
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: cnvrg-operator
       containers:
         - name: delete-cnvrgapp
-          image: docker.io/cnvrg/cnvrg-tools:v0.3
+          image: "{{ .Values.imageHub }}/cnvrg-tools:v0.3"
           args:
             - /bin/bash
             - -c


### PR DESCRIPTION
For installs that require an external registry we need to be able to specify the image path for the job kinds. The job images key now references the imageHub value to allow for this. 