### PR TITLE
DEV-21538 Update kube-state-metrics image and clusterRole

### DIFF
--- a/api/v1/monitoring.go
+++ b/api/v1/monitoring.go
@@ -179,7 +179,7 @@ var infraMonitoringDefault = CnvrgInfraMonitoring{
 	},
 	KubeStateMetrics: KubeStateMetrics{
 		Enabled: false,
-		Image:   "kube-state-metrics:v1.9.7",
+		Image:   "kube-state-metrics:v2.8.1",
 	},
 	NodeExporter: NodeExporter{
 		Enabled: false,

--- a/pkg/monitoring/tmpl/kube-state-metrics/clusterrole.tpl
+++ b/pkg/monitoring/tmpl/kube-state-metrics/clusterrole.tpl
@@ -112,6 +112,14 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
   verbs:
   - list
   - watch

--- a/pkg/monitoring/tmpl/kube-state-metrics/dep.tpl
+++ b/pkg/monitoring/tmpl/kube-state-metrics/dep.tpl
@@ -7,7 +7,7 @@ metadata:
     {{- end }}
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.7
+    app.kubernetes.io/version: v2.8.1
     {{- range $k, $v := .Spec.Labels }}
     {{$k}}: "{{$v}}"
     {{- end }}
@@ -26,7 +26,7 @@ spec:
         {{- end }}
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: v1.9.7
+        app.kubernetes.io/version: v2.8.1
         {{- range $k, $v := .Spec.Labels }}
         {{$k}}: "{{$v}}"
         {{- end }}

--- a/pkg/monitoring/tmpl/kube-state-metrics/servicemonitor.tpl
+++ b/pkg/monitoring/tmpl/kube-state-metrics/servicemonitor.tpl
@@ -7,7 +7,7 @@ metadata:
     {{- end }}
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: 2.8.1
     cnvrg-infra-prometheus: {{ .Name }}-{{ ns .}}
     {{- range $k, $v := .Spec.Labels }}
     {{$k}}: "{{$v}}"


### PR DESCRIPTION
Update cube-state-metrics to v2.8.1 - updated clusterRole to provide additional permissions required by the new version.

Details provided here
https://cnvrgio.atlassian.net/browse/DEV-21538