### PR TITLE
Dev-22113 airgap fix operator

### DIFF
--- a/charts/cnvrg-operator/templates/operator.yml
+++ b/charts/cnvrg-operator/templates/operator.yml
@@ -202,7 +202,7 @@ spec:
             - start
             - --max-concurrent-reconciles
             - "3"
-          image: "docker.io/cnvrg/cnvrg-operator:{{ .Chart.Version }}"
+          image: "{{ .Values.registry.url }}/cnvrg-operator:{{ .Chart.Version }}"
           imagePullPolicy: Always
           name: cnvrg-operator
           resources:

--- a/charts/cnvrg-operator/values.yaml
+++ b/charts/cnvrg-operator/values.yaml
@@ -1,5 +1,5 @@
 registry:
   name: cnvrg-app-registry
-  url: docker.io
+  url: docker.io/cnvrg
   user: ''
   password: ''


### PR DESCRIPTION
The image for the cnvrg operator in the operator.yml is currently hardcoded. This just updates the deployment to allow for defining a custom registry in the values file. 

Here is the DEV ticket https://cnvrgio.atlassian.net/browse/DEV-22113