### PR TITLE
Dev 22128 minio deploy strategy fix

### DIFF
--- a/api/v1/app.go
+++ b/api/v1/app.go
@@ -281,6 +281,7 @@ type Minio struct {
 	SvcName        string            `json:"svcName,omitempty"`
 	NodePort       int               `json:"nodePort,omitempty"`
 	StorageClass   string            `json:"storageClass,omitempty"`
+	UpdateStrategy string            `json:"updateStrategy,omitempty"`
 	Requests       Requests          `json:"requests,omitempty"`
 	Limits         Limits            `json:"limits,omitempty"`
 	NodeSelector   map[string]string `json:"nodeSelector,omitempty"`

--- a/api/v1/appdefaults.go
+++ b/api/v1/appdefaults.go
@@ -219,6 +219,7 @@ var minioDefaults = Minio{
 	SvcName:        "minio",
 	NodePort:       30090,
 	StorageClass:   "",
+	UpdateStrategy: "RollingUpdate",
 	Requests: Requests{
 		Cpu:    "200m",
 		Memory: "2Gi",

--- a/charts/cnvrg-cap/templates/cap.yml
+++ b/charts/cnvrg-cap/templates/cap.yml
@@ -220,6 +220,7 @@ spec:
       svcName: {{.Values.dbs.minio.svcName}}
       nodePort: {{.Values.dbs.minio.nodePort}}
       storageClass: {{.Values.dbs.minio.storageClass}}
+      updateStrategy: {{.Values.dbs.minio.updateStrategy}}
       requests:
         cpu: "{{.Values.dbs.minio.requests.cpu}}"
         memory: {{.Values.dbs.minio.requests.memory}}

--- a/charts/cnvrg-cap/values.yaml
+++ b/charts/cnvrg-cap/values.yaml
@@ -214,6 +214,7 @@ dbs:
     svcName: minio
     nodePort: 30090
     storageClass: ''
+    updateStrategy: RollingUpdate
     requests:
       cpu: 200m
       memory: 2Gi

--- a/charts/cnvrg-operator/crds/mlops.cnvrg.io_cnvrgapps.yaml
+++ b/charts/cnvrg-operator/crds/mlops.cnvrg.io_cnvrgapps.yaml
@@ -594,6 +594,8 @@ spec:
                         type: string
                       storageClass:
                         type: string
+                      updateStrategy:
+                        type: string
                       storageSize:
                         type: string
                       svcName:

--- a/pkg/app/dbs/tmpl/minio/dep.tpl
+++ b/pkg/app/dbs/tmpl/minio/dep.tpl
@@ -17,9 +17,12 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  {{- if ne .Spec.Dbs.Minio.UpdateStrategy "RollingUpdate" }}
   strategy:
-    type: Recreate
+    type: {{ .Spec.Dbs.Minio.UpdateStrategy }}
+  {{- if eq .Spec.Dbs.Minio.UpdateStrategy "RollingUpgrade" }}
+    rollingUpdate: 
+      maxSurge: 25%
+      maxUnavailable: 25%
   {{- end }}
   selector:
     matchLabels:

--- a/pkg/app/dbs/tmpl/minio/dep.tpl
+++ b/pkg/app/dbs/tmpl/minio/dep.tpl
@@ -17,6 +17,10 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Dbs.Minio.UpdateStrategy "RollingUpdate" }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Spec.Dbs.Minio.SvcName }}

--- a/pkg/app/dbs/tmpl/minio/dep.tpl
+++ b/pkg/app/dbs/tmpl/minio/dep.tpl
@@ -19,11 +19,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Spec.Dbs.Minio.UpdateStrategy }}
-  {{- if eq .Spec.Dbs.Minio.UpdateStrategy "RollingUpgrade" }}
+    {{- if eq .Spec.Dbs.Minio.UpdateStrategy "RollingUpgrade" }}
     rollingUpdate: 
       maxSurge: 25%
       maxUnavailable: 25%
-  {{- end }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ .Spec.Dbs.Minio.SvcName }}


### PR DESCRIPTION
Here is the Dev ticket:
https://cnvrgio.atlassian.net/browse/DEV-22128

This adds the ability to select the upgrade strategy for the minio deployment. The reason for the PR is some customers need to define the strategy as Recreate not RollingUpdate, this is due to the PVC being ReadWriteOnce. Their rolling upgrade fails due to only 1 pod can be attached to the minio volume at a time. 

Please let me know if you have any questions. 

Thanks!