### PR TITLE
Dev 22129 definable ingress class ingress.tpl

### DIFF
--- a/api/v1/app.go
+++ b/api/v1/app.go
@@ -361,6 +361,7 @@ type Ingress struct {
 	IstioIngressSelectorKey   string      `json:"istioIngressSelectorKey,omitempty"`
 	IstioIngressSelectorValue string      `json:"istioIngressSelectorValue,omitempty"`
 	OcpSecureRoutes           bool        `json:"ocpSecureRoutes,omitempty"`
+	IngressClassName          string      `json:"ingressClassName,omitempty"`
 }
 
 type HTTPS struct {

--- a/api/v1/appdefaults.go
+++ b/api/v1/appdefaults.go
@@ -439,6 +439,7 @@ var networkingDefault = Networking{
 		IstioIngressSelectorKey:   "istio",
 		IstioIngressSelectorValue: "ingressgateway",
 		OcpSecureRoutes:           false,
+		IngressClassName:          "",
 	},
 	HTTPS: HTTPS{Enabled: false},
 	Proxy: Proxy{Enabled: false, ConfigRef: "cp-proxy"},

--- a/charts/cnvrg-cap/templates/cap.yml
+++ b/charts/cnvrg-cap/templates/cap.yml
@@ -310,6 +310,7 @@ spec:
       istioIngressSelectorKey: {{.Values.networking.ingress.istioIngressSelectorKey}}
       istioIngressSelectorValue: {{.Values.networking.ingress.istioIngressSelectorValue}}
       ocpSecureRoutes: {{.Values.networking.ingress.ocpSecureRoutes}}
+      ingressClassName: {{.Values.networking.ingress.ingressClassName}}
     https:
       enabled: {{.Values.networking.https.enabled}}
       certSecret: {{.Values.networking.https.certSecret}}

--- a/charts/cnvrg-cap/values.yaml
+++ b/charts/cnvrg-cap/values.yaml
@@ -304,6 +304,7 @@ networking:
     istioIngressSelectorKey: 'istio'
     istioIngressSelectorValue: 'ingressgateway'
     ocpSecureRoutes: false
+    ingressClassName: ''
   https:
     enabled: false
     certSecret: ''

--- a/charts/cnvrg-operator/crds/mlops.cnvrg.io_cnvrgapps.yaml
+++ b/charts/cnvrg-operator/crds/mlops.cnvrg.io_cnvrgapps.yaml
@@ -775,6 +775,8 @@ spec:
                         type: string
                       ocpSecureRoutes:
                         type: boolean
+                      ingressClassName:
+                        type: string
                     type: object
                   proxy:
                     properties:

--- a/pkg/app/controlplane/tmpl/conf/cm/config-networking.tpl
+++ b/pkg/app/controlplane/tmpl/conf/cm/config-networking.tpl
@@ -38,3 +38,4 @@ data:
   {{- if isTrue .Spec.Networking.Ingress.OcpSecureRoutes }}
   OCP_SECURE_ROUTES: "true"
   {{- end }}
+  INGRESS_CLASS_NAME: {{ .Spec.Networking.Ingress.IngressClassName }}

--- a/pkg/app/controlplane/tmpl/webapp/ingress.tpl
+++ b/pkg/app/controlplane/tmpl/webapp/ingress.tpl
@@ -24,7 +24,7 @@ metadata:
   name: {{ .Spec.ControlPlane.WebApp.SvcName }}
   namespace: {{ .Namespace }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/controlplane/tmpl/webapp/ingress.tpl
+++ b/pkg/app/controlplane/tmpl/webapp/ingress.tpl
@@ -24,7 +24,9 @@ metadata:
   name: {{ .Spec.ControlPlane.WebApp.SvcName }}
   namespace: {{ .Namespace }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/es/elastalert/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/elastalert/ingress.tpl
@@ -21,7 +21,6 @@ spec:
   {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- end }}
-  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/es/elastalert/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/elastalert/ingress.tpl
@@ -18,6 +18,9 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:

--- a/pkg/app/dbs/tmpl/es/elastalert/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/elastalert/ingress.tpl
@@ -18,7 +18,7 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/es/elastic/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/elastic/ingress.tpl
@@ -18,7 +18,9 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/es/elastic/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/elastic/ingress.tpl
@@ -18,7 +18,7 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/es/kibana/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/kibana/ingress.tpl
@@ -24,7 +24,7 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/es/kibana/ingress.tpl
+++ b/pkg/app/dbs/tmpl/es/kibana/ingress.tpl
@@ -24,7 +24,9 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/minio/ingress.tpl
+++ b/pkg/app/dbs/tmpl/minio/ingress.tpl
@@ -18,7 +18,9 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/minio/ingress.tpl
+++ b/pkg/app/dbs/tmpl/minio/ingress.tpl
@@ -18,7 +18,7 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/prom/grafana/ingress.tpl
+++ b/pkg/app/dbs/tmpl/prom/grafana/ingress.tpl
@@ -24,7 +24,7 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/prom/grafana/ingress.tpl
+++ b/pkg/app/dbs/tmpl/prom/grafana/ingress.tpl
@@ -24,7 +24,9 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/prom/prometheus/ingress.tpl
+++ b/pkg/app/dbs/tmpl/prom/prometheus/ingress.tpl
@@ -18,7 +18,9 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
   ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/dbs/tmpl/prom/prometheus/ingress.tpl
+++ b/pkg/app/dbs/tmpl/prom/prometheus/ingress.tpl
@@ -18,7 +18,7 @@ metadata:
     {{$k}}: "{{$v}}"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/sso/tmpl/central/ingress.tpl
+++ b/pkg/app/sso/tmpl/central/ingress.tpl
@@ -18,7 +18,9 @@ metadata:
   name: {{.Spec.SSO.Central.SvcName}}
   namespace: {{.Namespace }}
 spec:
-  ingressClassName: nginx
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:

--- a/pkg/app/sso/tmpl/jwks/ingress.tpl
+++ b/pkg/app/sso/tmpl/jwks/ingress.tpl
@@ -18,7 +18,9 @@ metadata:
   name: {{ .Spec.SSO.Jwks.SvcName }}
   namespace: {{.Namespace }}
 spec:
-  ingressClassName: nginx
+  {{- if ne .Spec.Networking.Ingress.IngressClassName "" }}
+  ingressClassName: {{ .Spec.Networking.Ingress.IngressClassName }}
+  {{- end }}
   {{- if and ( isTrue .Spec.Networking.HTTPS.Enabled ) (ne .Spec.Networking.HTTPS.CertSecret "") }}
   tls:
   - hosts:


### PR DESCRIPTION
Some customers have multiple ingressClasses. They need a way to define the ingressClassName for the ingress objects. This PR will add the ability to define the ingressClass. If no ingressClassName is defined it will take the default ingressClass. 
This will also fix the issue we have with the ingress objects being hardcoded to the ingressClassName 'nginx'

Here is the dev ticket:
https://cnvrgio.atlassian.net/browse/DEV-22129