### PR TITLE
Update instance.tpl

### DIFF
--- a/pkg/networking/tmpl/istio/instance/instance.tpl
+++ b/pkg/networking/tmpl/istio/instance/instance.tpl
@@ -52,7 +52,9 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 80
+                target:
+                  averageUtilization: 80
+                  type: Utilization
               type: Resource
           minReplicas: 1
           scaleTargetRef:


### PR DESCRIPTION
updated hpa metrics resource spec for the ingressGateway. 

Please see the following Jira ticket:
https://cnvrgio.atlassian.net/browse/DEV-22175

This will fix the following error thrown by the istio-operator

     Error:   failed to update resource with server-side apply for obj HorizontalPodAutoscaler/cnvrg/cnvrg-ingressgateway: failed to create typed patch object (cnvrg/cnvrg-ingressgateway; autoscaling/v2, Kind=HorizontalPodAutoscaler): .spec.metrics[0].resource.targetAverageUtilization: field not declared in schema